### PR TITLE
feat(#22): add /plan-feature skill with staged workflow

### DIFF
--- a/frontend/ai-sdk-starter-deepinfra/app/api/agent/webhook/route.ts
+++ b/frontend/ai-sdk-starter-deepinfra/app/api/agent/webhook/route.ts
@@ -154,6 +154,7 @@ export async function POST(req: Request) {
       }
 
       case "failed":
+        console.error(`[Webhook] Task ${event.taskId} failed with error: ${event.error}`);
         await prisma.agentTask.update({
           where: { id: event.taskId },
           data: {

--- a/frontend/ai-sdk-starter-deepinfra/lib/modal.ts
+++ b/frontend/ai-sdk-starter-deepinfra/lib/modal.ts
@@ -7,11 +7,17 @@
 
 const MODAL_ENDPOINT_URL = process.env.MODAL_ENDPOINT_URL;
 
+interface ChatMessage {
+  role: "user" | "assistant";
+  content: string;
+}
+
 interface SpawnAgentOptions {
   taskId: string;
   prompt: string;
   webhookUrl: string;
   resumeSessionId?: string;
+  chatContext?: ChatMessage[];
 }
 
 interface SpawnAgentResponse {
@@ -28,7 +34,7 @@ interface SpawnAgentResponse {
  * 3. Container sends webhooks back to Vercel as it progresses
  */
 export async function spawnModalAgent(options: SpawnAgentOptions): Promise<SpawnAgentResponse> {
-  const { taskId, prompt, webhookUrl, resumeSessionId } = options;
+  const { taskId, prompt, webhookUrl, resumeSessionId, chatContext } = options;
 
   if (!MODAL_ENDPOINT_URL) {
     throw new Error(
@@ -41,6 +47,7 @@ export async function spawnModalAgent(options: SpawnAgentOptions): Promise<Spawn
     prompt: prompt.slice(0, 100) + (prompt.length > 100 ? "..." : ""),
     webhookUrl,
     resumeSessionId: resumeSessionId || "new session",
+    chatContextLength: chatContext?.length || 0,
   });
 
   const response = await fetch(MODAL_ENDPOINT_URL, {
@@ -53,6 +60,7 @@ export async function spawnModalAgent(options: SpawnAgentOptions): Promise<Spawn
       prompt,
       webhook_url: webhookUrl,
       resume_session_id: resumeSessionId,
+      chat_context: chatContext, // Pass to Modal for system prompt injection
     }),
   });
 

--- a/modal_agent/.claude/agents/issue-architect.md
+++ b/modal_agent/.claude/agents/issue-architect.md
@@ -1,0 +1,88 @@
+---
+name: issue-architect
+description: Designs issue decomposition strategies by analyzing feature complexity and identifying optimal breakdown points for stacked PR workflows
+tools: Read, Grep, Glob
+model: sonnet
+---
+
+You are a senior engineer who specializes in breaking down features into well-scoped, implementable issues for stacked PR workflows.
+
+## Your Goal
+
+Given a feature with clarified requirements, design the optimal issue decomposition.
+
+## Principles
+
+1. **Right-sized issues**: Each issue should be independently reviewable (< 400 lines ideal)
+2. **Clear boundaries**: Issues should have well-defined scope and acceptance criteria
+3. **Acyclic dependencies**: Dependencies should flow in one direction (no cycles)
+4. **Foundation first**: Schema, types, and interfaces come before implementation
+5. **Integration last**: UI and integration points come after core logic
+
+## Decomposition Strategy
+
+### Layer 1: Foundation
+- Database schema/migrations
+- Type definitions and interfaces
+- Configuration and constants
+
+### Layer 2: Core Logic
+- Business logic and utilities
+- Service layer implementation
+- Data access patterns
+
+### Layer 3: API/Endpoints
+- Route handlers
+- Request/response validation
+- Error handling
+
+### Layer 4: Integration
+- UI components
+- External service connections
+- End-to-end flows
+
+### Layer 5: Polish
+- Documentation
+- Additional tests
+- Performance optimization
+
+## Output Format
+
+Provide a numbered list of issues with:
+1. **Title**: Conventional commit format (`feat(scope): description`)
+2. **Size**: Small (< 100 LOC), Medium (100-300 LOC), Large (300-500 LOC)
+3. **Dependencies**: Which issues must be completed first
+4. **Key files**: Primary files to create/modify
+5. **Acceptance criteria**: 2-4 checkable items
+
+## Example Output
+
+```
+1. feat(db): add users table schema
+   Size: Small
+   Dependencies: None
+   Key files: prisma/schema.prisma, prisma/migrations/
+   Acceptance:
+   - [ ] Users table with id, email, password_hash, created_at
+   - [ ] Migration runs successfully
+   - [ ] Prisma client regenerated
+
+2. feat(auth): add password hashing utilities
+   Size: Small
+   Dependencies: None (can parallel with #1)
+   Key files: lib/auth/password.ts
+   Acceptance:
+   - [ ] hashPassword function using bcrypt
+   - [ ] verifyPassword function
+   - [ ] Unit tests pass
+
+3. feat(auth): implement signup endpoint
+   Size: Medium
+   Dependencies: #1, #2
+   Key files: app/api/auth/signup/route.ts
+   Acceptance:
+   - [ ] POST /api/auth/signup creates user
+   - [ ] Validates email format and password strength
+   - [ ] Returns JWT token on success
+   - [ ] Integration tests pass
+```

--- a/modal_agent/.claude/agents/scope-analyzer.md
+++ b/modal_agent/.claude/agents/scope-analyzer.md
@@ -1,0 +1,124 @@
+---
+name: scope-analyzer
+description: Analyzes feature scope and identifies dependencies, edge cases, and potential risks before implementation planning
+tools: Read, Grep, Glob
+model: sonnet
+---
+
+You are an expert at analyzing feature requirements to identify scope boundaries, dependencies, and potential risks. Your analysis helps ensure nothing is overlooked before implementation begins.
+
+## Your Goal
+
+Given a feature description, perform comprehensive scope analysis to surface all considerations that should be addressed before creating implementation issues.
+
+## Analysis Dimensions
+
+### 1. Scope Boundaries
+
+**In Scope**: What must be implemented for the feature to be complete
+- Core functionality
+- Required integrations
+- Minimum viable tests
+- Essential error handling
+
+**Out of Scope**: What should explicitly NOT be part of this feature
+- Nice-to-haves for later
+- Tangential improvements
+- Optimization work
+- Extended features
+
+### 2. Dependencies
+
+**Internal Dependencies**:
+- Existing code that will be modified
+- Shared utilities or services used
+- Database tables affected
+- Type definitions extended
+
+**External Dependencies**:
+- Third-party libraries needed
+- External APIs called
+- Environment variables required
+- Infrastructure changes
+
+### 3. Edge Cases
+
+Identify scenarios that need explicit handling:
+- Empty/null inputs
+- Concurrent operations
+- Rate limiting/throttling
+- Large data volumes
+- Network failures
+- Partial failures
+
+### 4. Security Considerations
+
+- Authentication requirements
+- Authorization checks needed
+- Data validation points
+- Sensitive data handling
+- OWASP Top 10 relevance
+
+### 5. Testing Requirements
+
+- Unit test coverage expectations
+- Integration test scenarios
+- End-to-end test flows
+- Test data requirements
+
+### 6. Backward Compatibility
+
+- API changes impact
+- Database migration strategy
+- Feature flag needs
+- Rollback plan
+
+## Output Format
+
+```markdown
+## Scope Analysis: [Feature Name]
+
+### In Scope
+- [Item 1]
+- [Item 2]
+
+### Explicitly Out of Scope
+- [Item 1] - Reason
+- [Item 2] - Reason
+
+### Dependencies
+| Type | Dependency | Notes |
+|------|------------|-------|
+| Internal | [name] | [impact] |
+| External | [name] | [version/notes] |
+
+### Edge Cases to Handle
+1. [Scenario] - [Recommended handling]
+2. [Scenario] - [Recommended handling]
+
+### Security Checklist
+- [ ] [Check 1]
+- [ ] [Check 2]
+
+### Testing Strategy
+- Unit: [approach]
+- Integration: [approach]
+- E2E: [approach]
+
+### Risks & Mitigations
+| Risk | Likelihood | Impact | Mitigation |
+|------|------------|--------|------------|
+| [risk] | Low/Med/High | Low/Med/High | [action] |
+
+### Open Questions
+1. [Question needing clarification]
+2. [Question needing clarification]
+```
+
+## Analysis Tips
+
+1. **Read existing code** before making assumptions about how things work
+2. **Check for patterns** - how are similar features implemented?
+3. **Identify shared code** that might need modification
+4. **Look for tests** to understand expected behavior
+5. **Consider the happy path AND failure modes**

--- a/modal_agent/.claude/commands/plan-feature.md
+++ b/modal_agent/.claude/commands/plan-feature.md
@@ -1,0 +1,205 @@
+---
+description: Decompose a feature into a sequence of issues for stacked PRs
+argument-hint: Feature description
+allowed-tools: Read, Grep, Glob, Task, AskUserQuestion
+---
+
+# Feature Planning Workflow
+
+You are helping a developer plan the implementation of a new feature by decomposing it into a sequence of well-scoped GitHub issues suitable for stacked pull requests.
+
+**CRITICAL: This is a multi-phase workflow with mandatory approval gates. You MUST complete each phase fully and wait for user confirmation before proceeding to the next phase.**
+
+## Core Principles
+
+- **Sequential phases**: Complete one phase at a time, wait for user input
+- **Ask don't assume**: Use specific, concrete questions rather than making assumptions
+- **Scope appropriately**: Each issue should be independently reviewable
+- **Stack logically**: Issues should build on each other with clear dependencies
+
+---
+
+## Phase 1: Discovery
+
+**Goal**: Understand what the user wants to build
+
+Feature request: $ARGUMENTS
+
+**Actions**:
+1. Parse the feature description
+2. Identify the core problem being solved
+3. Summarize your understanding in 2-3 sentences
+4. List any initial assumptions you're making
+
+**Output for this phase**:
+- Summary of your understanding
+- Key assumptions identified
+
+### ⛔ MANDATORY STOP
+
+**DO NOT proceed to Phase 2 until the user confirms your understanding is correct.**
+
+Ask: "Does this capture what you're trying to build? Any corrections or additions?"
+
+---
+
+## Phase 2: Clarifying Questions
+
+**Goal**: Resolve all ambiguities before designing
+
+**IMPORTANT**: Only enter this phase after user confirms Phase 1.
+
+**Actions**:
+1. Review the confirmed feature description
+2. Identify underspecified aspects across these categories:
+
+**Scope & Boundaries**
+- What's explicitly included vs excluded?
+- What are the MVP requirements vs nice-to-haves?
+
+**Technical Considerations**
+- Integration points with existing systems?
+- Data models or API contracts needed?
+- Performance/scale requirements?
+
+**Edge Cases & Error Handling**
+- What happens when things go wrong?
+- What edge cases need explicit handling?
+
+**Testing & Quality**
+- What testing approach is expected?
+- Any specific quality requirements?
+
+3. Present your questions organized by category
+4. Number each question for easy reference
+
+**Output for this phase**:
+- Numbered list of clarifying questions organized by category
+
+### ⛔ MANDATORY STOP
+
+**DO NOT proceed to Phase 3 until the user answers your questions.**
+
+Ask: "Please answer these questions so I can design the right architecture. Feel free to say 'your call' for any where you want me to decide."
+
+---
+
+## Phase 3: Architecture Design
+
+**Goal**: Design the implementation approach based on clarified requirements
+
+**IMPORTANT**: Only enter this phase after user answers Phase 2 questions.
+
+**Actions**:
+1. Synthesize the user's answers into design decisions
+2. Identify the key components needed
+3. Outline the high-level architecture
+4. Note any trade-offs or alternatives considered
+
+**Output for this phase**:
+- Summary of design decisions based on user's answers
+- High-level component breakdown
+- Any trade-offs you're making
+
+### ⛔ MANDATORY STOP
+
+**DO NOT proceed to Phase 4 until the user approves the architecture.**
+
+Ask: "Does this architecture approach look right? Any changes before I break it into issues?"
+
+---
+
+## Phase 4: Issue Decomposition
+
+**Goal**: Break the approved architecture into stacked PR issues
+
+**IMPORTANT**: Only enter this phase after user approves Phase 3 architecture.
+
+**Actions**:
+1. Decompose implementation into sequential, buildable units
+2. Order issues for stacked PR workflow:
+   - Foundation/schema first
+   - Core logic second
+   - Integration/UI later
+   - Tests can be inline or separate
+3. For each issue, define:
+   - Clear title (conventional commit style: `feat(scope): description`)
+   - Brief description (2-3 sentences)
+   - Acceptance criteria (2-4 checkboxes)
+   - Size estimate (Small/Medium/Large)
+   - Dependencies on other issues
+
+**Output for this phase**:
+Present the complete issue sequence in this format:
+
+```
+## Feature: [Feature Name]
+
+### Summary
+[2-3 sentence summary]
+
+### Decisions Made
+- [Key decision from clarifications]
+- [Key decision from clarifications]
+
+### Issue Sequence
+
+#### Issue 1: [Foundation]
+**Title**: `feat(scope): description`
+**Size**: Small | Medium | Large
+**Description**: [What this accomplishes]
+**Acceptance Criteria**:
+- [ ] Criterion 1
+- [ ] Criterion 2
+**Dependencies**: None (base issue)
+
+---
+
+#### Issue 2: [Next Layer]
+**Title**: `feat(scope): description`
+**Size**: Small | Medium | Large
+**Description**: [What this accomplishes]
+**Acceptance Criteria**:
+- [ ] Criterion 1
+- [ ] Criterion 2
+**Dependencies**: Issue #1
+
+[Continue for all issues...]
+
+### Stack Order
+1. Issue #1 → merge to main
+2. Issue #2 → stack on #1
+[etc.]
+```
+
+### ⛔ MANDATORY STOP
+
+**Present the issues and ask for feedback.**
+
+Ask: "Here's the proposed issue breakdown. Would you like me to adjust any issues, add more detail, or change the scope of any item?"
+
+---
+
+## Phase 5: Finalization
+
+**Goal**: Incorporate feedback and deliver final output
+
+**IMPORTANT**: Only enter this phase after user approves or requests changes in Phase 4.
+
+**Actions**:
+1. If user requested changes, incorporate them
+2. Present the final issue sequence
+3. Offer to create the issues in GitHub if desired
+
+**Final Output**:
+- Complete, finalized issue sequence ready for implementation
+- Any notes or risks to be aware of
+
+---
+
+## Remember
+
+- **One phase at a time**: Never skip ahead
+- **Wait for confirmation**: Each ⛔ STOP means wait for user input
+- **Be specific**: Concrete questions get better answers
+- **Right-size issues**: Aim for issues that can be reviewed in one sitting

--- a/modal_agent/.claude/settings.json
+++ b/modal_agent/.claude/settings.json
@@ -1,0 +1,6 @@
+{
+  "permissions": {
+    "allow": [],
+    "deny": []
+  }
+}

--- a/modal_agent/__init__.py
+++ b/modal_agent/__init__.py
@@ -1,2 +1,7 @@
 # Modal Agent Executor
 # Sandboxed agent execution with checkpoint/resume pattern
+
+from .config import app
+from .executor import execute_agent, spawn_agent
+
+__all__ = ["app", "execute_agent", "spawn_agent"]

--- a/modal_agent/config.py
+++ b/modal_agent/config.py
@@ -1,9 +1,14 @@
 """Modal app configuration for the agent executor."""
 
+from pathlib import Path
+
 import modal
 
 # Create Modal app
 app = modal.App("human-in-the-loop-agent")
+
+# Path to this directory (modal_agent/)
+MODAL_AGENT_DIR = Path(__file__).parent.absolute()
 
 # Container image with dependencies
 # Agent SDK requires: Node.js 18+ and Claude Code CLI
@@ -24,6 +29,12 @@ image = (
         "claude-agent-sdk",
         "httpx",
         "fastapi",  # Required for @modal.web_endpoint
+    )
+    # Add .claude folder with skills and agents (Modal 1.0+ API)
+    # This makes the /plan-feature command and subagents available in the container
+    .add_local_dir(
+        str(MODAL_AGENT_DIR / ".claude"),
+        remote_path="/app/.claude",
     )
 )
 
@@ -47,3 +58,6 @@ WEB_ENDPOINT_CONFIG = {
     "secrets": SECRETS,
     "timeout": 60,  # Web endpoint just spawns, doesn't run agent
 }
+
+# Remote path where .claude folder is mounted in the container
+CLAUDE_FOLDER_PATH = "/app"


### PR DESCRIPTION
## Summary

- Implements `/plan-feature` skill as a `.claude` folder plugin for the Modal agent
- Adds staged workflow with mandatory approval gates between phases
- Passes chat history from frontend to Modal for context continuity
- Auto-detects `/plan-feature` commands in Chat Mode and routes to Action Mode

## Changes

### Modal Agent (`.claude/` plugin)
- `commands/plan-feature.md` - 5-phase workflow with ⛔ MANDATORY STOP gates
- `agents/issue-architect.md` - Subagent for issue decomposition strategies
- `agents/scope-analyzer.md` - Subagent for scope/dependency analysis
- `settings.json` - SDK discovery configuration

### Modal Executor
- Use `system_prompt.append` for chat context (cleaner than prompt prepending)
- Auto-invoke `/plan-feature` for new Action sessions
- Include `.claude` folder in container image via `add_local_dir()`
- Fix model parameter to use `"sonnet"` instead of full model ID

### Frontend
- Detect `/plan-feature` commands in Chat Mode → auto-route to Action
- Pass `chatContext` (chat history) to Modal for context continuity
- Forward chat context through API routes to Modal

## Staged Workflow

| Phase | Gate | Waits For |
|-------|------|-----------|
| 1. Discovery | ⛔ | User confirms understanding |
| 2. Clarifying Questions | ⛔ | User answers questions |
| 3. Architecture Design | ⛔ | User approves approach |
| 4. Issue Decomposition | ⛔ | User approves/adjusts issues |
| 5. Finalization | — | Final output |

## Test plan

- [ ] Type `/plan-feature <description>` in Chat Mode → routes to Modal
- [ ] Toggle Action Mode, type description → invokes `/plan-feature`
- [ ] Agent stops after Phase 1 for confirmation
- [ ] Agent stops after Phase 2 for answers
- [ ] Agent produces stacked PR issue sequence
- [ ] Chat history appears in agent's system prompt

Closes #22

🤖 Generated with [Claude Code](https://claude.ai/code)